### PR TITLE
Fixed typo:  you -> your

### DIFF
--- a/data/features/deployment.yaml
+++ b/data/features/deployment.yaml
@@ -2,5 +2,5 @@
 weight: 40
 name: "Deployment"
 icon: "fa fa-server fa-2x"
-description: "How to get you Plone site up and running."
+description: "How to get your Plone site up and running."
 link: "https://training.plone.org/5/deployment/index.html"


### PR DESCRIPTION
Fixed typo on Plone main training page:
* you -> your