### PR TITLE
Add WSGI training to front page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 1.0a2 - Unreleased
 -------------------
 
+- Add WSGI training to front page [tschorr]
+
 - Fix CSS min-height for 3-line description. [jensens]
 
 - Fix: use weight as sort value and set menaingful weights. [jensens]

--- a/data/features/wsgi.yaml
+++ b/data/features/wsgi.yaml
@@ -1,5 +1,5 @@
 ---
-weight: 130
+weight: 41
 name: "WSGI Deployment"
 icon: "fa fa-concierge-bell fa-2x"
 description: "Deploying and Operating Plone on WSGI"

--- a/data/features/wsgi.yaml
+++ b/data/features/wsgi.yaml
@@ -1,0 +1,6 @@
+---
+weight: 130
+name: "WSGI Deployment"
+icon: "fa fa-concierge-bell fa-2x"
+description: "Deploying and Operating Plone on WSGI"
+link: "https://training.plone.org/5/wsgi/index.html"


### PR DESCRIPTION
We need to add the WSGI training to training.plone.org. Here's the yaml, pls tell me if you need anything else.